### PR TITLE
Fetching DAOs balances only for registered DAOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DAOs Balances Service
 
-A service to get a sorted DAOs total holdings (ETH + erc20) array in USD via APIs <br/> The service returns total balance and formatted total balance for each DAO
+A service to get a sorted **registered** DAOs total holdings (ETH + erc20) array in USD via APIs <br/> The service returns total balance and formatted total balance for each DAO
 
 ![image](./images/daos-balances-service-graph.jpeg)
 

--- a/routes/daosBalance.js
+++ b/routes/daosBalance.js
@@ -21,7 +21,7 @@ const fetchDaos = (version, network) => axios({
   method: 'POST',
   data: {
     query: `{
-      daos { 
+      daos (where: {register: "registered"}){ 
            id
            ${version === 'v2' ? "ethBalance" : ""}
       }
@@ -135,6 +135,10 @@ const startFetching = async (daosBalances) => {
    */
   router.get('/getDaosBalances/', (req, res, next) => {
     const { version, network, from, to } = req.query;
+    if (!daosBalances[version][network]) {
+      res.send([]);
+      return;
+    }
     res.send(daosBalances[version][network].slice(from, to));
   });
 


### PR DESCRIPTION
resolves: https://github.com/daostack/daos-balances/issues/2

- Returns balance only for registered DAOs
- Minor improvement - return empty array when does not support network instead of throwing an error

This PR is required to https://github.com/daostack/alchemy/pull/2089